### PR TITLE
Override plugin type on update

### DIFF
--- a/src/lkwdwrd/Composer/MULoaderPlugin.php
+++ b/src/lkwdwrd/Composer/MULoaderPlugin.php
@@ -68,7 +68,8 @@ class MULoaderPlugin implements PluginInterface, EventSubscriberInterface {
 	public static function getSubscribedEvents() {
 		return array(
 			'pre-autoload-dump' => 'dumpRequireFile',
-			'pre-package-install' => 'overridePluginTypes'
+			'pre-package-install' => 'overridePluginTypes',
+			'pre-package-update' => 'overridePluginTypes',
 		);
 	}
 	/**


### PR DESCRIPTION
When running `composer update`, plugins are going back to the regular plugins directory.