### PR TITLE
Normalize paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 /phpunit.xml
 /bootstrap.php
+/build

--- a/src/lkwdwrd/util/util.php
+++ b/src/lkwdwrd/util/util.php
@@ -23,8 +23,8 @@ const PS = DIRECTORY_SEPARATOR;
  */
 function rel_path( $from, $to, $ps = PS ) {
 	// Turn paths into array.
-	$arFrom = explode($ps, rtrim( $from, $ps ) );
-	$arTo = explode( $ps, rtrim( $to, $ps ) );
+	$arFrom = explode($ps, rtrim( normalize( $from, $ps ), $ps ) );
+	$arTo = explode( $ps, rtrim( normalize( $to, $ps ), $ps ) );
 	// Strip the common roots from both arrays.
 	while( count( $arFrom ) && count( $arTo ) && ( $arFrom[0] == $arTo[0] ) ) {
 		array_shift( $arFrom );
@@ -33,4 +33,15 @@ function rel_path( $from, $to, $ps = PS ) {
 	// for any itmes left in from, add '../' and then append the remaining
 	// to items.
 	return str_pad( '', count( $arFrom ) * 3, '..' . $ps ) . implode( $ps, $arTo );
+}
+
+/**
+ * Convert all different directory separators into one unified style
+ *
+ * @param  string $path The path to normalize
+ * @param  string $ds   The directory separator to standardize on
+ * @return string       The normalized path
+ */
+function normalize( $path, $ds ) {
+	return str_replace( array( '/', "\\" ), $ds, $path );
 }

--- a/tests/phpunit/list-table_Tests.php
+++ b/tests/phpunit/list-table_Tests.php
@@ -48,18 +48,19 @@ class List_Table_Tests extends TestCase {
 				'lastone/lastone.php'
 			]
 		] );
+		$base = WPMU_PLUGIN_DIR . DIRECTORY_SEPARATOR;
 		WP_Mock::wpFunction( 'get_plugin_data', [
-			'args' => ['/root/random/random.php', false ],
+			'args' => [$base . 'random/random.php', false ],
 			'return' => [
 				'Name' => 'Random MU Plugin'
 			]
 		] );
 		WP_Mock::wpFunction( 'get_plugin_data', [
-			'args' => ['/root/testing/notsame.php', false],
+			'args' => [$base . 'testing/notsame.php', false],
 			'return' => []
 		] );
 		WP_Mock::wpFunction( 'get_plugin_data', [
-			'args' => ['/root/lastone/lastone.php', false],
+			'args' => [$base . 'lastone/lastone.php', false],
 			'return' => [
 				'Name' => 'The Last One',
 				'arbitrary' => [ 1, 2, 3 ],

--- a/tests/phpunit/loader_Tests.php
+++ b/tests/phpunit/loader_Tests.php
@@ -109,7 +109,7 @@ class Loader_Tests extends TestCase {
 		// only plugins in directorys should pass: rootplugin.php will go away.
 		// WP will include root plugins in it's normal course.
 		WP_Mock::wpFunction( 'get_plugins', [
-			'args' => [ '/relpath' ],
+			'args' => [ DIRECTORY_SEPARATOR . 'relpath' ],
 			'return' => [
 				'random/plugin1.php' => true,
 				'random/plugin2.php' => true,

--- a/tests/phpunit/util_Tests.php
+++ b/tests/phpunit/util_Tests.php
@@ -28,12 +28,38 @@ class MULoaderPlugin_Tests extends TestCase {
 
 	/**
 	 * Make sure the rel_path function makes relative paths.
+	 * @dataProvider data_rel_path
 	 */
-	public function test_rel_path() {
-		$abspath1 = '/a/random/path/to/a/place';
-		$abspath2 = '/a/random/path/to/another/place';
+	public function test_rel_path( $path1, $path2, $sep, $expected) {
+		$this->assertEquals( Util\rel_path( $path1, $path2, $sep ), $expected );
+	}
 
-		$calculatedRel = Util\rel_path( $abspath1, $abspath2, '/' );
-		$this->assertEquals( $calculatedRel, '../../another/place' );
+	public function data_rel_path(){
+		return array(
+			array(
+				'/a/random/path/to/a/place',
+				'/a/random/path/to/another/place',
+				'/',
+				'../../another/place',
+			),
+			array(
+				'/somewhere/over/the/rainbow',
+				'/somewhere/over/the/rainbow/bluebirds/sing',
+				'/',
+				'bluebirds/sing',
+			),
+			array(
+				'/just/some/test',
+				'/just\some\mixed\slash\example',
+				'/',
+				'../mixed/slash/example',
+			),
+			array(
+				'/testing/inverse/directory/separators',
+				'/unix/to/windows',
+				'\\',
+				'..\..\..\..\unix\to\windows',
+			),
+		);
 	}
 }


### PR DESCRIPTION
This normalizes paths inside the rel_path function for maximum usefulness throughout the codebase. (This replaces #3)

I also took this opportunity to get the tests to pass in a windows environment.