### PR TITLE
Add ability to force unix separators in the mu plugin loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 /phpunit.xml
 /bootstrap.php
+/build

--- a/src/lkwdwrd/Composer/MULoaderPlugin.php
+++ b/src/lkwdwrd/Composer/MULoaderPlugin.php
@@ -134,8 +134,9 @@ class MULoaderPlugin implements PluginInterface, EventSubscriberInterface {
 
 		// Find the relative path from the mu-plugins dir to the mu-loader file.
 		$muPath = $this->resolveMURelPath( $muRelPath );
-		$loadFile = dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'mu-loader.php';
-		$toLoader = DIRECTORY_SEPARATOR . Util\rel_path( $muPath, $loadFile );
+		$ds = $this->getDirectorySeparator();
+		$loadFile = dirname( __DIR__ ) . $ds . 'mu-loader.php';
+		$toLoader = $ds . Util\rel_path( $muPath, $loadFile, $ds );
 
 		// Write the boostrapping PHP file.
 		if ( !file_exists( $muPath ) ) {
@@ -193,5 +194,22 @@ class MULoaderPlugin implements PluginInterface, EventSubscriberInterface {
 		$basepath = str_replace( $tag, '', $this->config->get('vendor-dir') );
 		// Return the abosolute path.
 		return $basepath . $relpath;
+	}
+
+	/**
+	 * Get the directory separator to use for the generatoed loader
+	 *
+	 * This defaults to the DIRECTORY_SEPARATOR constant, but can be overridden in
+	 * the composer.json extra section with "force-unix-separator" set to true.
+	 *
+	 * @return string The directory separator character to use
+	 */
+	protected function getDirectorySeparator() {
+		$separator = DIRECTORY_SEPARATOR;
+		if ( ! empty( $this->extras['force-unix-separator'] ) ) {
+			$separator = '/';
+		}
+
+		return $separator;
 	}
 }

--- a/tests/phpunit/list-table_Tests.php
+++ b/tests/phpunit/list-table_Tests.php
@@ -48,18 +48,19 @@ class List_Table_Tests extends TestCase {
 				'lastone/lastone.php'
 			]
 		] );
+		$base = WPMU_PLUGIN_DIR . DIRECTORY_SEPARATOR;
 		WP_Mock::wpFunction( 'get_plugin_data', [
-			'args' => ['/root/random/random.php', false ],
+			'args' => [$base . 'random/random.php', false ],
 			'return' => [
 				'Name' => 'Random MU Plugin'
 			]
 		] );
 		WP_Mock::wpFunction( 'get_plugin_data', [
-			'args' => ['/root/testing/notsame.php', false],
+			'args' => [$base . 'testing/notsame.php', false],
 			'return' => []
 		] );
 		WP_Mock::wpFunction( 'get_plugin_data', [
-			'args' => ['/root/lastone/lastone.php', false],
+			'args' => [$base . 'lastone/lastone.php', false],
 			'return' => [
 				'Name' => 'The Last One',
 				'arbitrary' => [ 1, 2, 3 ],

--- a/tests/phpunit/loader_Tests.php
+++ b/tests/phpunit/loader_Tests.php
@@ -109,7 +109,7 @@ class Loader_Tests extends TestCase {
 		// only plugins in directorys should pass: rootplugin.php will go away.
 		// WP will include root plugins in it's normal course.
 		WP_Mock::wpFunction( 'get_plugins', [
-			'args' => [ '/relpath' ],
+			'args' => [ DIRECTORY_SEPARATOR . 'relpath' ],
 			'return' => [
 				'random/plugin1.php' => true,
 				'random/plugin2.php' => true,


### PR DESCRIPTION
For those of us who work on a Windows environment locally, but using Vagrant or Docker, we need to be able to force the composer plugin to use unix directory separators. This adds a Composer extras option to indicate that this is the desired behavior.

```json
  "extras": {
    "force-unix-separator": true
  }
```