### PR TITLE
__DIR__ does not always make it into mu-require.php unescaped, and mu composer type lost on update

### DIFF
--- a/src/lkwdwrd/Composer/MULoaderPlugin.php
+++ b/src/lkwdwrd/Composer/MULoaderPlugin.php
@@ -91,7 +91,7 @@ class MULoaderPlugin implements PluginInterface, EventSubscriberInterface {
 		// Get the package being worked on.
 		$operation = $event->getOperation();
 		if ( $operation instanceof \Composer\DependencyResolver\Operation\UpdateOperation ) {
-			$package = $operation->getInitialPackage();
+			$package = $operation->getTargetPackage();
 		} else {
 			$package = $operation->getPackage();
 		}

--- a/src/lkwdwrd/Composer/MULoaderPlugin.php
+++ b/src/lkwdwrd/Composer/MULoaderPlugin.php
@@ -142,9 +142,11 @@ class MULoaderPlugin implements PluginInterface, EventSubscriberInterface {
 		if ( !file_exists( $muPath ) ) {
 			mkdir( $muPath, 0755, true );
 		}
+		// Must break up __DIR__ constant when inside double quotes, or sometimes it
+		// will be filled with the Composer runtime value for __DIR__
 		file_put_contents(
 			$muPath . 'mu-require.php',
-			"<?php\nrequire_once __DIR__ . '${toLoader}';\n"
+			"<?php\nrequire_once __DI" . "R__ . '${toLoader}';\n"
 		);
 	}
 	/**


### PR DESCRIPTION
This PR addresses an issue I encountered where mu-require.php gets generated with an absolute start to the path. I believe this may be the (or a) cause of Issue #2. With an absolute path, the require statement is very likely to break if the code is moved elsewhere, or immediately depending on the configuration for web server, virtual machine, etc.

Specifically, in some circumstances mu-require.php ends up being written something like this:
`require_once '/path/to/repo/vendor/lkwdwrd/wp-muplugin-loader/src/lkwdwrd/Composer' . '/../../vendor/lkwdwrd/wp-muplugin-loader/src/lkwdwrd/mu-loader.php';`

When it needs to always end up something like this:
`require_once __DIR__ . '/../../vendor/lkwdwrd/wp-muplugin-loader/src/lkwdwrd/mu-loader.php';`

It seems like the __DIR__ constant is being replaced by its actual value at composer run time in some circumstances, yet not in others. I can understand why PHP might grab it since it's inside double quotes, though I'm not sure why it's not consistent. `composer require` and `composer remove` seem to trigger it a lot, especially if I am not working in the same directory as composer.json at the time. Whereas `composer install` seems to pretty reliably NOT replace the __DIR__ with the constant's value.

Breaking the string into two concatenated segments in the middle of the __DIR__ constant works around this. Even on composer require and composer remove, I consistently get the actual __DIR__ constant output in my mu-require.php file.